### PR TITLE
Add redraw-everything button.

### DIFF
--- a/public/index.js
+++ b/public/index.js
@@ -24,10 +24,14 @@ $(document).ready(async () => {
         ws: ws,
     });
 
+    let main_widget;
+
     async function redraw_everything() {
-        const main_page = await window.main.render(page_params);
+        const main_page = await main_widget.render();
         $('#main').html(main_page);
     }
+
+    main_widget = window.main.make(redraw_everything);
 
     redraw_everything();
 });

--- a/public/main.js
+++ b/public/main.js
@@ -20,27 +20,38 @@ window.main = (() => {
 
     const main_pane_widget = window.split_pane.make(pane_config);
 
-    async function render(page_params) {
-        const top_div = $('<div>');
-        top_div.text(`${_.me().full_name} - `);
-        const link = $('<a>', {
-            text: `Server: ${model().state.server}`,
-            href: model().state.server,
-        });
-        top_div.append(link);
+    function make(redraw_callback) {
+        async function render() {
+            const top_div = $('<div>');
+            top_div.text(`${_.me().full_name} - `);
+            const link = $('<a>', {
+                text: `Server: ${model().state.server}`,
+                href: model().state.server,
+            });
+            top_div.append(link);
 
-        const main_pane = await main_pane_widget.render();
+            const redraw_button = $('<button>').text('redraw app');
 
-        const page = $('<div>');
-        page.append(top_div);
-        page.append('<hr>');
+            redraw_button.on('click', redraw_callback);
 
-        page.append(main_pane);
+            const main_pane = await main_pane_widget.render();
 
-        return page;
+            const page = $('<div>');
+            page.append($('<div>').html(redraw_button));
+            page.append(top_div);
+            page.append('<hr>');
+
+            page.append(main_pane);
+
+            return page;
+        }
+
+        return {
+            render: render,
+        };
     }
 
     return {
-        render: render,
+        make: make,
     };
 })();


### PR DESCRIPTION
Note that our split_pane widgets have no state,
so we always go back to tictactoe, which itself
doesn't manage state (it always re-creates the
data during render).

I can fix this tomorrow.