### PR TITLE
events: Implement event queue, message fetching and live rerendering.

### DIFF
--- a/public/events.js
+++ b/public/events.js
@@ -1,6 +1,4 @@
 window.events = (() => {
-    let ws = undefined;
-
     const handle_model_updates = (event) => {
         try {
             model(event.model);
@@ -10,14 +8,15 @@ window.events = (() => {
         }
     };
 
-    const init = (_ws) => {
-        ws = _ws;
+    const init = (ws) => {
         console.log('init events');
         ws.onmessage = (message) => {
             const event = JSON.parse(message.data);
             console.log('got message', event);
             if (event.type === 'update') {
                 handle_model_updates(event);
+            } else if (event.type === 'tictactoe') {
+                window.tictactoe.handle_event(event);
             }
         };
     };

--- a/public/events.js
+++ b/public/events.js
@@ -1,0 +1,25 @@
+window.events = (() => {
+    let ws = undefined;
+
+    const handle_model_updates = (event) => {
+        try {
+            model(event.model);
+            $(document).trigger('zulipRedrawEverything');
+        } catch (e) {
+            console.error('Error updating model:', event, e);
+        }
+    };
+
+    const init = (_ws) => {
+        ws = _ws;
+        console.log('init events');
+        ws.onmessage = (message) => {
+            const event = JSON.parse(message.data);
+            console.log('got message', event);
+            if (event.type === 'update') {
+                handle_model_updates(event);
+            }
+        };
+    };
+    return init;
+})();

--- a/public/index.css
+++ b/public/index.css
@@ -53,3 +53,10 @@ img {
 .split-pane .items > div {
     padding: 1px;
 }
+
+.message-list {
+    height: 100%;
+    overflow-y: scroll;
+    display: flex;
+    flex-direction: column-reverse;
+}

--- a/public/index.js
+++ b/public/index.js
@@ -25,12 +25,17 @@ $(document).ready(async () => {
         ws: ws,
     });
 
+    events(ws);
+
     let main_widget;
 
     async function redraw_everything() {
+        console.log('Redrawing');
         const main_page = await main_widget.render();
         $('#main').html(main_page);
     }
+
+    $(document).on('zulipRedrawEverything', redraw_everything);
 
     main_widget = window.main.make(redraw_everything);
 

--- a/public/index.js
+++ b/public/index.js
@@ -20,11 +20,8 @@ $(document).ready(async () => {
     };
 
     await init_data();
-    window.tictactoe.initialize({
-        params: page_params.game,
-        ws: ws,
-    });
 
+    window.tictactoe.initialize(ws);
     events(ws);
 
     let main_widget;

--- a/public/model.js
+++ b/public/model.js
@@ -6,7 +6,12 @@ window.model = (() => {
             },
         ],
         streams: [{}],
-        messages: [{}],
+        messages: [
+            {
+                id: 1,
+                content: 'string',
+            },
+        ],
         state: {
             user_id: 1,
             server: 'string',
@@ -65,13 +70,38 @@ window.model = (() => {
         has_same_structure(new_model, base_model);
     };
 
+    const merge = (new_model) => {
+        const merge_messages = (a, b) => {
+            // for conflicts: overwrite local message with one from server.
+            b.forEach((m) => {
+                const idx = a.findIndex((e) => e.id === m.id);
+                if (idx === -1) {
+                    a.push(m);
+                } else {
+                    a[idx] = m;
+                }
+            });
+            return a;
+        };
+
+        const opts = {
+            customMerge: (key) => {
+                if (key === 'messages') {
+                    return merge_messages;
+                }
+            },
+        };
+        model = deepmerge(model, new_model, opts);
+        return model;
+    };
+
     const main = (new_model, overwrite = false) => {
         if (new_model) {
             verify(new_model);
             if (overwrite) {
                 model = new_model;
             } else {
-                model = deepmerge(model, new_model);
+                model = merge(new_model);
             }
         }
         return model;

--- a/public/pm_view.js
+++ b/public/pm_view.js
@@ -6,7 +6,7 @@ window.pm_view = (() => {
         let div;
 
         function render() {
-            div = $('<div>');
+            div = $('<div>').addClass('message-list');
             message_data = _.find_pms_with(user.user_id);
             div.html('building');
             populate(div);
@@ -17,8 +17,8 @@ window.pm_view = (() => {
             const message_table = messages.build_message_table(message_data);
 
             div.empty();
-            div.append(message_table);
             div.append(compose_box.build_for_user(user));
+            div.append(message_table);
         }
 
         return {

--- a/public/pm_view.js
+++ b/public/pm_view.js
@@ -3,45 +3,18 @@ window.pm_view = (() => {
         let fetched = false;
         let message_data;
 
-        async function get_message_data(user_id) {
-            const narrow = JSON.stringify([
-                {
-                    operator: 'pm-with',
-                    operand: [user_id],
-                },
-            ]);
-            const response = await fetch(
-                `/z/messages?num_before=5&anchor=newest&num_after=0&narrow=${narrow}`
-            );
-            message_data = await response.json();
-
-            fetched = true;
-        }
-
         let div;
 
         function render() {
             div = $('<div>');
-
-            if (fetched) {
-                console.log('already fetched!');
-                div.html('building');
-                populate(div);
-                return div;
-            }
-
-            get_message_data(user.user_id).then(() => {
-                populate(div);
-            });
-
-            div.html('loading');
+            message_data = _.find_pms_with(user.user_id);
+            div.html('building');
+            populate(div);
             return div;
         }
 
         function populate(div) {
-            const message_table = messages.build_message_table(
-                message_data.messages
-            );
+            const message_table = messages.build_message_table(message_data);
 
             div.empty();
             div.append(message_table);

--- a/public/tictactoe.js
+++ b/public/tictactoe.js
@@ -274,7 +274,6 @@ window.tictactoe = (() => {
     function initialize(opts) {
         game_info = opts.params;
         ws = opts.ws;
-
         ws.onmessage = (message) => {
             const event = JSON.parse(message.data);
             console.log('got ws message', event);

--- a/public/tictactoe.js
+++ b/public/tictactoe.js
@@ -271,18 +271,17 @@ window.tictactoe = (() => {
         return active_game;
     }
 
-    function initialize(opts) {
-        game_info = opts.params;
-        ws = opts.ws;
-        ws.onmessage = (message) => {
-            const event = JSON.parse(message.data);
-            console.log('got ws message', event);
-            active_game.handle_event(event);
-        };
+    function handle_event(event) {
+        active_game.handle_event(event);
+    }
+
+    function initialize(_ws) {
+        ws = _ws;
     }
 
     return {
         initialize: initialize,
         make: make,
+        handle_event: handle_event,
     };
 })();

--- a/public/utils.js
+++ b/public/utils.js
@@ -23,4 +23,16 @@ window._ = {
         }
         return streams;
     },
+    find_pms_with: (user_id) => {
+        let messages = model().messages;
+        return messages.filter((m) => {
+            if (m.type !== 'private') {
+                return false;
+            }
+            if (m.display_recipient.findIndex((e) => e.id === user_id) !== -1) {
+                return true;
+            }
+            return false;
+        });
+    },
 };

--- a/src/client_events.js
+++ b/src/client_events.js
@@ -1,0 +1,47 @@
+const make = (client) => {
+    return;
+};
+
+const queue = require('./queue');
+
+const send_model_update = (json, client) => {
+    client.ws.send(
+        JSON.stringify({
+            type: 'update',
+            model: json,
+        })
+    );
+};
+
+const process_event = (event, client) => {
+    if (!event) return;
+    if (event.type === 'message') {
+        send_model_update(
+            {
+                messages: [event.message],
+            },
+            client
+        );
+    }
+};
+
+module.exports = (zulip, client) => {
+    const call_on_each = (event) => {
+        process_event(event, client);
+    };
+    const z = zulip.get_raw_methods(client.session);
+    z.get('messages', {
+        num_before: 1000,
+        num_after: 0,
+        anchor: 'newest',
+    }).then((res) => {
+        send_model_update(
+            {
+                messages: res.messages,
+            },
+            client
+        );
+        console.log('Loaded messages: ', res.messages.length);
+    });
+    queue(z)(call_on_each, ['message', 'realm_emoji']);
+};

--- a/src/game.js
+++ b/src/game.js
@@ -21,6 +21,7 @@ exports.handle_message = (clients, client, message) => {
     payload = {
         message: JSON.parse(message),
         user_id: client.user_id,
+        type: 'tictactoe',
     };
     clients.forEach((client) => {
         console.info('about to reply', JSON.stringify(payload));

--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,7 @@ const http = require('http');
 const process = require('process');
 const sessionHandler = require('express-session');
 const WebSocket = require('ws');
+const client_events = require('./client_events');
 
 const game = require('./game');
 const zulip = require('./zulip');
@@ -175,6 +176,7 @@ server.on('upgrade', function (request, socket, head) {
             const client = {
                 ws: ws,
                 user_id: user_id,
+                session: request.session,
             };
             clients.push(client);
 
@@ -188,6 +190,7 @@ server.on('upgrade', function (request, socket, head) {
             ws.on('message', (message) => {
                 game.handle_message(clients, client, message);
             });
+            client_events(z, client);
         });
     });
 });

--- a/src/queue.js
+++ b/src/queue.js
@@ -1,0 +1,62 @@
+function sleep(ms) {
+    // TODO add jitter.
+    return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+module.exports = (z) => {
+    function logError(error) {
+        console.log('zulip-js: Error while communicating with server:', error);
+    }
+
+    async function registerQueue(req, eventTypes = null) {
+        let res;
+        while (true) {
+            try {
+                const params = { eventTypes };
+                res = await z.post('register', params);
+                if (res.result === 'error') {
+                    logError(res.msg);
+                    await sleep(1000);
+                } else {
+                    return {
+                        queueId: res.queue_id,
+                        lastEventId: res.last_event_id,
+                    };
+                }
+            } catch (e) {
+                logError(e);
+            }
+        }
+    }
+
+    async function callOnEachEvent(callback, eventTypes = null) {
+        let queueId = null;
+        let lastEventId = -1;
+        const handleEvent = (event) => {
+            lastEventId = Math.max(lastEventId, event.id);
+            callback(event);
+        };
+        while (true) {
+            if (!queueId) {
+                const queueData = await registerQueue(eventTypes);
+                queueId = queueData.queueId;
+                lastEventId = queueData.lastEventId;
+            }
+            try {
+                const res = await z.get('events', {
+                    queue_id: queueId,
+                    last_event_id: lastEventId,
+                    dont_block: false,
+                });
+                if (res.events) {
+                    res.events.forEach(handleEvent);
+                }
+            } catch (e) {
+                logError(e);
+            }
+            await sleep(1000);
+        }
+    }
+
+    return callOnEachEvent;
+};

--- a/src/zulip.js
+++ b/src/zulip.js
@@ -95,6 +95,11 @@ exports.make = function (opts) {
         await pipe(url, req.query, res);
     }
 
+    function get_raw_methods(session) {
+        const helper = get_helper(session);
+        return helper;
+    }
+
     return {
         api_get: api_get,
         api_post: api_post,
@@ -102,5 +107,6 @@ exports.make = function (opts) {
         get_current_user: get_current_user,
         handle_user_uploads: handle_user_uploads,
         oauth_prefix: oauth_prefix,
+        get_raw_methods: get_raw_methods,
     };
 };

--- a/views/index.pug
+++ b/views/index.pug
@@ -7,7 +7,6 @@ html
         script(src='https://unpkg.com/deepmerge@4.2.2/dist/umd.js')
         script(src='/split_pane.js')
         script(src='/model.js')
-        script(src='/events.js')
         script(src='/utils.js')
         script(src='/pm_view.js')
         script(src='/compose_box.js')
@@ -15,6 +14,7 @@ html
         script(src='/users.js')
         script(src='/streams.js')
         script(src='/tictactoe.js')
+        script(src='/events.js')
         script(src='/main.js')
         script(src='/index.js')
         script

--- a/views/index.pug
+++ b/views/index.pug
@@ -7,6 +7,7 @@ html
         script(src='https://unpkg.com/deepmerge@4.2.2/dist/umd.js')
         script(src='/split_pane.js')
         script(src='/model.js')
+        script(src='/events.js')
         script(src='/utils.js')
         script(src='/pm_view.js')
         script(src='/compose_box.js')


### PR DESCRIPTION
This is one big commit that adds structurally sound foundation for a
realtime events implementation. As a test, we can now send someone a
PM and see it reflected live in the UI.

To do this, the proxy server registers one event queue for each client
and parcels any data updates (for now only messages) to be sent to the
client via their websocket.

On receiving this new information, the client updates the model().
Each model() update now triggers a redraw of the whole UI.

Misc:

- add helper function for filtering messages.
- add merging code for messages in Model() so we can process message edits.
- borrow and modify queues implementation from zulip-js.