### PR TITLE
message-list: Add styling and separate sender name.

### DIFF
--- a/public/index.css
+++ b/public/index.css
@@ -158,6 +158,21 @@ table.game-board,
     flex-direction: column-reverse;
 }
 
+.message-list-wrapper {
+    list-style-type: none;
+    padding-inline-start: 10px;
+    font-family: 'Source Sans Pro', 'Helvetica Neue', Helvetica, Arial,
+        sans-serif;
+}
+
+.message-list-wrapper .message {
+    padding-inline-start: 12px;
+}
+
+.message-list-wrapper .name {
+    padding-top: 3px;
+}
+
 .compose-box {
     width: 100%;
     display: flex;

--- a/public/messages.js
+++ b/public/messages.js
@@ -1,12 +1,19 @@
 window.messages = (() => {
     function build_message_table(messages) {
-        const message_ul = $('<ul>');
+        const message_ul = $('<ul>').addClass('message-list-wrapper');
 
-        for (const msg of messages) {
-            const li = $('<li>');
-            li.append($('<b>').text(msg.sender_full_name));
-            li.append($('<br>'));
-            li.append(msg.content);
+        for (let i = 0; i < messages.length; i++) {
+            if (
+                i == 0 ||
+                messages[i - 1].sender_full_name != messages[i].sender_full_name
+            ) {
+                // add names as separate <li>s without repetition
+                const name = $('<li>').addClass('name');
+                name.append($('<b>').text(messages[i].sender_full_name));
+                message_ul.append(name);
+            }
+            const li = $('<li>').addClass('message');
+            li.append(messages[i].content);
             message_ul.append(li);
         }
 


### PR DESCRIPTION
Here we really on classes to apply styles (and
override user agent styles) so that we do not
assume the message list is a <ul>.

![image](https://user-images.githubusercontent.com/33805964/99558434-bd00d800-29e9-11eb-88c5-4db0cb19ff7a.png)

