### PR TITLE
Fix split_pane things.

### DIFF
--- a/client/split_pane.js
+++ b/client/split_pane.js
@@ -15,6 +15,7 @@ window.split_pane = (() => {
         let right;
         let search_val = '';
         let search;
+        let items_div;
         let active_key;
         let active_conf;
 
@@ -42,7 +43,8 @@ window.split_pane = (() => {
             search = $('<input>').attr({ type: 'text' });
             search.val(search_val);
 
-            populate();
+            populate_left();
+            populate_right();
 
             return pane;
         }
@@ -54,7 +56,8 @@ window.split_pane = (() => {
 
                 button.css('opacity', '50%');
                 right.html('loading...');
-                populate();
+                update_items();
+                populate_right();
             };
         }
 
@@ -75,17 +78,22 @@ window.split_pane = (() => {
             }
 
             const search_div = $('<div>').addClass('search');
-            const items_div = $('<div>').addClass('items');
+            items_div = $('<div>').addClass('items');
             search_div.append(search);
             left.append(search_div);
             left.append(items_div);
 
             search.on('keyup', async () => {
                 search_val = search.val().toLowerCase();
-                populate(pane);
-                console.info('focus search box in keyup');
+                update_items();
+                populate_right();
                 search.focus();
             });
+            update_items();
+        }
+
+        function update_items() {
+            items_div.empty();
 
             keys.forEach((key, idx) => {
                 if (!is_key_visible(key)) {
@@ -121,14 +129,9 @@ window.split_pane = (() => {
             }
         }
 
-        function populate(pane) {
-            populate_left();
-            populate_right();
-        }
-
         function update() {
             keys = get_keys();
-            populate_left();
+            update_items();
 
             if (!active_conf) {
                 return;

--- a/client/split_pane.js
+++ b/client/split_pane.js
@@ -9,18 +9,14 @@ window.split_pane = (() => {
             throw Error('misconfigured split_pane');
         }
 
-        let keys = get_keys();
+        let keys;
         let pane;
         let left;
         let right;
         let search_val = '';
         let search;
-        let active_key = keys[0];
+        let active_key;
         let active_conf;
-
-        if (active_key) {
-            active_conf = right_handler(active_key);
-        }
 
         function render() {
             if (get_keys) {
@@ -63,6 +59,9 @@ window.split_pane = (() => {
         }
 
         function is_key_visible(key) {
+            if (!key) {
+                return false;
+            }
             const label = key_to_label(key);
             return label.toLowerCase().includes(search_val);
         }
@@ -117,6 +116,8 @@ window.split_pane = (() => {
             if (is_key_visible(active_key)) {
                 const right_contents = active_conf.render();
                 right.html(right_contents);
+            } else {
+                right.text('Please select an item or clear the filter.');
             }
         }
 


### PR DESCRIPTION
This makes it less noisy for the user (for example,
I don't want to see an "announce" message list),
plus it makes it so that on page load we defer
some work (which concerns me for stuff like console
noise than actual performance).

Note that the split_pane widgets are still sticky
from the perspective of the tab_bar.  We may
eventually want to just have the tab_bar be more
like an app launcher and when you move away from
a tab, we effectively close it.  (This is tied
to some of our upcoming re-think on how the layout
widget works.)